### PR TITLE
Fixes pidgtm_compile_times bug

### DIFF
--- a/database/migrations/2023-12-29-222652_migration5/down.sql
+++ b/database/migrations/2023-12-29-222652_migration5/down.sql
@@ -1,8 +1,7 @@
--- Commands to drop the new table for error logs
 DROP TABLE IF EXISTS error_logs;
 
--- Commands to revert the repurposed table to its original form
-ALTER TABLE pidgtm_compile_times DROP COLUMN calculation_timestamp;
-ALTER TABLE pidgtm_compile_times ALTER COLUMN time_in_seconds SET DATA TYPE INTEGER;
-ALTER TABLE pidgtm_compile_times RENAME COLUMN time_in_seconds TO player_id;
-ALTER TABLE pidgtm_compile_times RENAME TO last_checked_player_id;
+DROP TABLE IF EXISTS pidgtm_compile_times;
+
+CREATE TABLE last_checked_player_id (
+    player_id INTEGER PRIMARY KEY
+);

--- a/database/migrations/2023-12-29-222652_migration5/up.sql
+++ b/database/migrations/2023-12-29-222652_migration5/up.sql
@@ -1,10 +1,11 @@
--- Commands to repurpose the existing table
-ALTER TABLE last_checked_player_id RENAME TO pidgtm_compile_times;
-ALTER TABLE pidgtm_compile_times RENAME COLUMN player_id TO time_in_seconds;
-ALTER TABLE pidgtm_compile_times ALTER COLUMN time_in_seconds SET DATA TYPE INTEGER;
-ALTER TABLE pidgtm_compile_times ADD COLUMN calculation_timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+DROP TABLE IF EXISTS last_checked_player_id;
 
--- Commands to create a new table for error logs
+CREATE TABLE pidgtm_compile_times (
+    id SERIAL PRIMARY KEY,
+    time_in_seconds INT NOT NULL,
+    calculation_timestamp TIMESTAMP
+);
+
 CREATE TABLE error_logs (
     id SERIAL PRIMARY KEY,
     error_timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/database/src/db_models/pidgtm_compile_times.rs
+++ b/database/src/db_models/pidgtm_compile_times.rs
@@ -1,7 +1,7 @@
 use crate::schema::pidgtm_compile_times;
 use diesel::prelude::*;
 
-#[derive(Debug, Insertable, Queryable, QueryableByName)]
+#[derive(Debug, Insertable)]
 #[diesel(table_name = pidgtm_compile_times)]
 pub struct PidgtmCompileTimes {
     pub time_in_seconds: i32,

--- a/database/src/schema.rs
+++ b/database/src/schema.rs
@@ -15,9 +15,10 @@ diesel::table! {
 }
 
 diesel::table! {
-    pidgtm_compile_times (time_in_seconds) {
+    pidgtm_compile_times (id) {
+        id -> Int4,
         time_in_seconds -> Int4,
-        calculation_timestamp -> Timestamp,
+        calculation_timestamp -> Nullable<Timestamp>,
     }
 }
 

--- a/lib/src/common.rs
+++ b/lib/src/common.rs
@@ -52,7 +52,7 @@ where
 {
     let running = Arc::new(AtomicUsize::new(0));
 
-    if is_cli {
+    if is_cli && std::env::var("CTRLC_HANDLER_SET").is_err() {
         let r = running.clone();
         ctrlc::set_handler(move || {
             let prev = r.fetch_add(1, Ordering::SeqCst);
@@ -62,6 +62,9 @@ where
                 process::exit(0);
             }
         })?;
+
+        // set env var indicating ctrlc handler is set
+        std::env::set_var("CTRLC_HANDLER_SET", "true");
     }
 
     let mut curr_page = start;

--- a/src/pidgtm/compile.rs
+++ b/src/pidgtm/compile.rs
@@ -61,3 +61,20 @@ pub async fn handle_compile(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use smithe_lib::common::init_logger;
+    use anyhow::Result;
+
+    use super::*;
+
+    const RANDOM_ID: i32 = 26324;
+
+    #[tokio::test]
+    async fn test_handle_compile() -> Result<()> {
+        init_logger()?;
+        handle_compile(Some(RANDOM_ID), Some(RANDOM_ID + 1)).await?;
+        Ok(())
+    }
+}

--- a/src/pidgtm/compile.rs
+++ b/src/pidgtm/compile.rs
@@ -64,8 +64,8 @@ pub async fn handle_compile(
 
 #[cfg(test)]
 mod tests {
-    use smithe_lib::common::init_logger;
     use anyhow::Result;
+    use smithe_lib::common::init_logger;
 
     use super::*;
 


### PR DESCRIPTION
- `time_in_seconds` from `pidgtm_compile_times` was being considered an ID, so we were getting unique pkey violations.
- ctrlc handler was being set multiple times.